### PR TITLE
remove xray version check

### DIFF
--- a/pkg/xray/provider.go
+++ b/pkg/xray/provider.go
@@ -157,22 +157,12 @@ func (p *XrayProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 		)
 	}
 
-	version, err := util.GetXrayVersion(restyClient)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error getting Xray version",
-			err.Error(),
-		)
-		return
-	}
-
 	featureUsage := fmt.Sprintf("Terraform/%s", req.TerraformVersion)
 	go util.SendUsage(ctx, restyClient.R(), productId, featureUsage)
 
 	meta := util.ProviderMetadata{
-		Client:      restyClient,
-		ProductId:   productId,
-		XrayVersion: version,
+		Client:    restyClient,
+		ProductId: productId,
 	}
 
 	p.Meta = meta


### PR DESCRIPTION
I think the simplest is to just remove this check.

Basically, I rebuilt the provider and tested locally if it works. No errors were raised in dev workspace without active licence.

Before we had:
```
╷
│ Error: Error getting Xray version
│ 
│   with provider["registry.terraform.io/jfrog/xray"],
│   on main.tf line 69, in provider "xray":
│   69: provider "xray" {
│ 
│ failed to get Xray version.
```
even when we didn't try to create any resources..

Alternative:
- add another option flag in e.g `skip_xray_version_check` with default value false (keeping the same behaviour as today)
```
// XrayProviderModel describes the provider data model.
type XrayProviderModel struct {
	Url                  types.String `tfsdk:"url"`
	AccessToken          types.String `tfsdk:"access_token"`
	OIDCProviderName     types.String `tfsdk:"oidc_provider_name"`
	TFCCredentialTagName types.String `tfsdk:"tfc_credential_tag_name"`
        SkipXrayVersionCheck types.Bool `tfsdk:"skip_xray_version_check"`
}
```
then in our terraform provider config we would just set: `skip_xray_version_check: local.use_licence ? true : false`

This was actually behaviour of artifactory provider long time ago. They had: `check_licence` or similar...